### PR TITLE
Serve a simple string on /v1/style.

### DIFF
--- a/api_auth.go
+++ b/api_auth.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// StyleHandler reports this auth backend's "style" attribute. This is reported through cloudpipe
+// to API consumers to provide them with a hint about other auth interactions that are possible at
+// this endpoint.
+func StyleHandler(c *Context, w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+	fmt.Fprintf(w, "auth-store")
+}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,9 @@ func main() {
 		"address": c.ListenAddr(),
 	}).Info("Auth API listening.")
 
+	// v1 routes
+	http.HandleFunc("/v1/style", BindContext(c, StyleHandler))
+
 	http.ListenAndServeTLS(c.ListenAddr(), c.Cert, c.Key, nil)
 }
 


### PR DESCRIPTION
The first, and easiest, part of the [auth protocol](https://github.com/cloudpipe/cloudpipe/wiki/Authentication). Let's use the repo name as the style.
