### PR TITLE
Serve on both an internal and external port.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is the default implementation of the [cloudpipe authentication backend prot
 
  1. Install [Docker](https://docs.docker.com/installation/mac/) on your system.
  2. Install [fig](http://www.fig.sh/install.html).
- 3. Use `script/genkeys` to generate a self-signed TLS certificate in `certificates/`.
+ 3. Use `script/genkeys` to generate self-signed TLS keypairs in `certificates/`.
  4. Run `fig build && fig up -d` to build and launch everything locally.
 
 To run the tests, use `script/test`. You can also use `script/mongo` to connect to your local MongoDB database.

--- a/README.md
+++ b/README.md
@@ -24,13 +24,10 @@ Once it's up and running, you can use `curl` to interact the auth API. Here are 
 DOCKER=$(boot2docker ip 2>/dev/null)
 
 # Create a new account.
-curl -k -i -X POST https://${DOCKER}:8001/v1/accounts -d 'accountName=me%40gmail.com&password=shhh'
+curl -k -i -X POST https://${DOCKER}:9000/v1/accounts -d 'accountName=me%40gmail.com&password=shhh'
 
 # Generate a new API key.
-KEY=$(curl -k -X POST https://${DOCKER}:8001/v1/keys -d 'accountName=me%40gmail.com&password=shhh')
-
-# Validate an existing key.
-curl -k -i "https://${DOCKER}:8001/v1/validate?accountName=me%40gmail.com&apiKey=${KEY}"
+curl -k -i -X POST https://${DOCKER}:9000/v1/keys -d 'accountName=me%40gmail.com&password=shhh'
 ```
 
 ### API Documentation

--- a/context.go
+++ b/context.go
@@ -62,6 +62,14 @@ func (c *Context) Load() error {
 		c.InternalKey = "/certificates/auth-store-key.pem"
 	}
 
+	if c.ExternalCert == "" {
+		c.ExternalCert = "/certificates/external-cert.pem"
+	}
+
+	if c.ExternalKey == "" {
+		c.ExternalKey = "/certificates/external-key.pem"
+	}
+
 	if _, err := log.ParseLevel(c.LogLevel); err != nil {
 		return err
 	}

--- a/context.go
+++ b/context.go
@@ -16,13 +16,16 @@ type Context struct {
 
 // Settings contains configuration options loaded from the environment.
 type Settings struct {
-	Port      int
-	LogLevel  string
-	LogColors bool
-	MongoURL  string
-	CACert    string
-	Cert      string
-	Key       string
+	InternalPort   int
+	ExternalPort   int
+	LogLevel       string
+	LogColors      bool
+	MongoURL       string
+	InternalCACert string
+	InternalCert   string
+	InternalKey    string
+	ExternalCert   string
+	ExternalKey    string
 }
 
 // Load reads configuration settings from the environment and validates them.
@@ -31,8 +34,12 @@ func (c *Context) Load() error {
 		return err
 	}
 
-	if c.Port == 0 {
-		c.Port = 8000
+	if c.InternalPort == 0 {
+		c.InternalPort = 8001
+	}
+
+	if c.ExternalPort == 0 {
+		c.ExternalPort = 8000
 	}
 
 	if c.LogLevel == "" {
@@ -43,16 +50,16 @@ func (c *Context) Load() error {
 		c.MongoURL = "mongo"
 	}
 
-	if c.CACert == "" {
-		c.CACert = "/certificates/ca.pem"
+	if c.InternalCACert == "" {
+		c.InternalCACert = "/certificates/ca.pem"
 	}
 
-	if c.Cert == "" {
-		c.Cert = "/certificates/auth-store-cert.pem"
+	if c.InternalCert == "" {
+		c.InternalCert = "/certificates/auth-store-cert.pem"
 	}
 
-	if c.Key == "" {
-		c.Key = "/certificates/auth-store-key.pem"
+	if c.InternalKey == "" {
+		c.InternalKey = "/certificates/auth-store-key.pem"
 	}
 
 	if _, err := log.ParseLevel(c.LogLevel); err != nil {
@@ -85,13 +92,16 @@ func NewContext() (*Context, error) {
 	// Summarize the loaded settings.
 
 	log.WithFields(log.Fields{
-		"port":           c.Port,
-		"logging level":  c.LogLevel,
-		"log with color": c.LogColors,
-		"mongo URL":      c.MongoURL,
-		"CA cert":        c.CACert,
-		"cert":           c.Cert,
-		"key":            c.Key,
+		"internal port":    c.InternalPort,
+		"external port":    c.ExternalPort,
+		"logging level":    c.LogLevel,
+		"log with color":   c.LogColors,
+		"mongo URL":        c.MongoURL,
+		"internal CA cert": c.InternalCACert,
+		"internal cert":    c.InternalCert,
+		"internal key":     c.InternalKey,
+		"external cert":    c.ExternalCert,
+		"external key":     c.ExternalKey,
 	}).Info("Initializing with loaded settings.")
 
 	// Connect to MongoDB
@@ -104,7 +114,12 @@ func NewContext() (*Context, error) {
 	return c, nil
 }
 
-// ListenAddr generates an address to bind the net/http server to based on the current settings.
-func (c *Context) ListenAddr() string {
-	return fmt.Sprintf(":%d", c.Port)
+// InternalListenAddr generates an address to bind the private net/http server to.
+func (c *Context) InternalListenAddr() string {
+	return fmt.Sprintf(":%d", c.InternalPort)
+}
+
+// ExternalListenAddr generates an address to bind the public net/http server to.
+func (c *Context) ExternalListenAddr() string {
+	return fmt.Sprintf(":%d", c.ExternalPort)
 }

--- a/context.go
+++ b/context.go
@@ -35,11 +35,11 @@ func (c *Context) Load() error {
 	}
 
 	if c.InternalPort == 0 {
-		c.InternalPort = 8001
+		c.InternalPort = 9001
 	}
 
 	if c.ExternalPort == 0 {
-		c.ExternalPort = 8000
+		c.ExternalPort = 9000
 	}
 
 	if c.LogLevel == "" {

--- a/context_test.go
+++ b/context_test.go
@@ -8,20 +8,27 @@ import (
 func TestLoadFromEnvironment(t *testing.T) {
 	c := &Context{}
 
-	os.Setenv("AUTH_PORT", "4321")
+	os.Setenv("AUTH_INTERNALPORT", "1111")
+	os.Setenv("AUTH_EXTERNALPORT", "2222")
 	os.Setenv("AUTH_LOGLEVEL", "debug")
 	os.Setenv("AUTH_LOGCOLORS", "true")
 	os.Setenv("AUTH_MONGOURL", "server.example.com")
-	os.Setenv("AUTH_CACERT", "/lockbox/ca.pem")
-	os.Setenv("AUTH_CERT", "/lockbox/cert.pem")
-	os.Setenv("AUTH_KEY", "/lockbox/key.pem")
+	os.Setenv("AUTH_INTERNALCACERT", "/lockbox/internal-ca.pem")
+	os.Setenv("AUTH_INTERNALCERT", "/lockbox/internal-cert.pem")
+	os.Setenv("AUTH_INTERNALKEY", "/lockbox/internal-key.pem")
+	os.Setenv("AUTH_EXTERNALCERT", "/lockbox/external-cert.pem")
+	os.Setenv("AUTH_EXTERNALKEY", "/lockbox/external-key.pem")
 
 	if err := c.Load(); err != nil {
 		t.Fatalf("Error loading configuration: %v", err)
 	}
 
-	if c.Port != 4321 {
-		t.Errorf("Unexpected port: [%d]", c.Port)
+	if c.InternalPort != 1111 {
+		t.Errorf("Unexpected internal port: [%d]", c.InternalPort)
+	}
+
+	if c.ExternalPort != 2222 {
+		t.Errorf("Unexpected external port: [%d]", c.ExternalPort)
 	}
 
 	if c.LogLevel != "debug" {
@@ -36,36 +43,51 @@ func TestLoadFromEnvironment(t *testing.T) {
 		t.Errorf("Unexpected MongoDB URL: [%s]", c.MongoURL)
 	}
 
-	if c.CACert != "/lockbox/ca.pem" {
-		t.Errorf("Unexpected CA certificate path: [%s]", c.CACert)
+	if c.InternalCACert != "/lockbox/internal-ca.pem" {
+		t.Errorf("Unexpected internal CA certificate path: [%s]", c.InternalCACert)
 	}
 
-	if c.Cert != "/lockbox/cert.pem" {
-		t.Errorf("Unexpected certificate path: [%s]", c.Cert)
+	if c.InternalCert != "/lockbox/internal-cert.pem" {
+		t.Errorf("Unexpected internal certificate path: [%s]", c.InternalCert)
 	}
 
-	if c.Key != "/lockbox/key.pem" {
-		t.Errorf("Unexpected private key path: [%s]", c.Key)
+	if c.InternalKey != "/lockbox/internal-key.pem" {
+		t.Errorf("Unexpected internal private key path: [%s]", c.InternalKey)
+	}
+
+	if c.ExternalCert != "/lockbox/external-cert.pem" {
+		t.Errorf("Unexpected external certificate path: [%s]", c.ExternalCert)
+	}
+
+	if c.ExternalKey != "/lockbox/external-key.pem" {
+		t.Errorf("Unexpected external private key path: [%s]", c.ExternalKey)
 	}
 }
 
 func TestDefaultValues(t *testing.T) {
 	c := &Context{}
 
-	os.Setenv("AUTH_PORT", "")
+	os.Setenv("AUTH_INTERNALPORT", "")
+	os.Setenv("AUTH_EXTERNALPORT", "")
 	os.Setenv("AUTH_LOGLEVEL", "")
 	os.Setenv("AUTH_LOGCOLORS", "")
 	os.Setenv("AUTH_MONGOURL", "")
-	os.Setenv("AUTH_CACERT", "")
-	os.Setenv("AUTH_CERT", "")
-	os.Setenv("AUTH_KEY", "")
+	os.Setenv("AUTH_INTERNALCACERT", "")
+	os.Setenv("AUTH_INTERNALCERT", "")
+	os.Setenv("AUTH_INTERNALKEY", "")
+	os.Setenv("AUTH_EXTERNALCERT", "")
+	os.Setenv("AUTH_EXTERNALKEY", "")
 
 	if err := c.Load(); err != nil {
 		t.Fatalf("Error loading configuration: %v", err)
 	}
 
-	if c.Port != 8000 {
-		t.Errorf("Unexpected port: [%d]", c.Port)
+	if c.InternalPort != 8001 {
+		t.Errorf("Unexpected internal port: [%d]", c.InternalPort)
+	}
+
+	if c.ExternalPort != 8000 {
+		t.Errorf("Unexpected external port: [%d]", c.ExternalPort)
 	}
 
 	if c.LogLevel != "info" {
@@ -80,15 +102,23 @@ func TestDefaultValues(t *testing.T) {
 		t.Errorf("Unexpected MongoDB URL: [%s]", c.MongoURL)
 	}
 
-	if c.CACert != "/certificates/ca.pem" {
-		t.Errorf("Unexpected CA certificate path: [%s]", c.CACert)
+	if c.InternalCACert != "/certificates/ca.pem" {
+		t.Errorf("Unexpected internal CA certificate path: [%s]", c.InternalCACert)
 	}
 
-	if c.Cert != "/certificates/auth-store-cert.pem" {
-		t.Errorf("Unexpected certificate path: [%s]", c.Cert)
+	if c.InternalCert != "/certificates/auth-store-cert.pem" {
+		t.Errorf("Unexpected internal certificate path: [%s]", c.InternalCert)
 	}
 
-	if c.Key != "/certificates/auth-store-key.pem" {
-		t.Errorf("Unexpected private key path: [%s]", c.Key)
+	if c.InternalKey != "/certificates/auth-store-key.pem" {
+		t.Errorf("Unexpected internal private key path: [%s]", c.InternalKey)
+	}
+
+	if c.ExternalCert != "" {
+		t.Errorf("Unexpected external certificate path: [%s]", c.ExternalCert)
+	}
+
+	if c.ExternalKey != "" {
+		t.Errorf("Unexpected external private key: [%s]", c.ExternalKey)
 	}
 }

--- a/context_test.go
+++ b/context_test.go
@@ -114,11 +114,11 @@ func TestDefaultValues(t *testing.T) {
 		t.Errorf("Unexpected internal private key path: [%s]", c.InternalKey)
 	}
 
-	if c.ExternalCert != "" {
+	if c.ExternalCert != "/certificates/external-cert.pem" {
 		t.Errorf("Unexpected external certificate path: [%s]", c.ExternalCert)
 	}
 
-	if c.ExternalKey != "" {
+	if c.ExternalKey != "/certificates/external-key.pem" {
 		t.Errorf("Unexpected external private key: [%s]", c.ExternalKey)
 	}
 }

--- a/context_test.go
+++ b/context_test.go
@@ -82,11 +82,11 @@ func TestDefaultValues(t *testing.T) {
 		t.Fatalf("Error loading configuration: %v", err)
 	}
 
-	if c.InternalPort != 8001 {
+	if c.InternalPort != 9001 {
 		t.Errorf("Unexpected internal port: [%d]", c.InternalPort)
 	}
 
-	if c.ExternalPort != 8000 {
+	if c.ExternalPort != 9000 {
 		t.Errorf("Unexpected external port: [%d]", c.ExternalPort)
 	}
 

--- a/fig.yml
+++ b/fig.yml
@@ -3,8 +3,10 @@ authstore:
   build: .
   links:
   - mongo
+  expose:
+  - "9001"
   ports:
-  - "8001:8000"
+  - "9000:9000"
   volumes:
   - "certificates:/certificates"
 mongo:

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ func main() {
 	}
 
 	log.WithFields(log.Fields{
-		"address": c.ListenAddr(),
+		"address": c.InternalListenAddr(),
 	}).Info("Auth API listening.")
 
 	// v1 routes
@@ -28,7 +28,7 @@ func main() {
 	http.HandleFunc("/v1/accounts", BindContext(c, AccountHandler))
 	http.HandleFunc("/v1/keys", BindContext(c, KeyHandler))
 
-	err = http.ListenAndServeTLS(c.ListenAddr(), c.Cert, c.Key, nil)
+	err = http.ListenAndServeTLS(c.InternalListenAddr(), c.InternalCert, c.InternalKey, nil)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"error": err,

--- a/script/genkeys
+++ b/script/genkeys
@@ -7,6 +7,17 @@ cd ${ROOT}
 
 OPENSSL="docker run --volume ${ROOT}/certificates:/certificates --rm smashwilson/openssl"
 
-${OPENSSL} openssl req -x509 -newkey rsa:2048 -days 365 -nodes -batch \
-  -keyout /certificates/auth-store-key.pem \
-  -out /certificates/auth-store-cert.pem
+# selfsigned generates a self-signed keypair.
+selfsigned()
+{
+  local NAME=$1
+
+  echo ">> generating keypair for ${NAME}"
+  ${OPENSSL} openssl req -x509 -newkey rsa:2048 -days 365 -nodes -batch \
+    -keyout /certificates/${NAME}-key.pem \
+    -out /certificates/${NAME}-cert.pem
+  echo "<< keypair generated for ${NAME}"
+}
+
+selfsigned "auth-store"
+selfsigned "external"


### PR DESCRIPTION
Isolate the API endpoints that should only be accessible from cloudpipe from those that should only be accessible from the external network.

Fixes #10.
